### PR TITLE
[#470] fix: socket creation with prefix always

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -34,7 +34,8 @@ import {
   altpaymentListener,
   CURRENCY_PREFIXES_MAP,
   CRYPTO_CURRENCIES,
-  isPropsTrue
+  isPropsTrue,
+  getAddressPrefixed
 } from '../../util';
 import AltpaymentWidget from './AltpaymentWidget';
 import { AltpaymentPair, AltpaymentShift, AltpaymentError, AltpaymentCoin, MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT } from '../../altpayment';
@@ -413,7 +414,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
       }
       const newSocket = io(`${wsBaseUrl ?? config.wsBaseUrl}/addresses`, {
         forceNew: true,
-        query: { addresses: [to], dummy: 'hehe' },
+        query: { addresses: [getAddressPrefixed(to)] },
       });
       setSocket(newSocket);
       txsListener(newSocket, setNewTxs);

--- a/react/lib/util/address.ts
+++ b/react/lib/util/address.ts
@@ -38,3 +38,32 @@ export default {
   isValidXecAddress,
   getCurrencyTypeFromAddress,
 };
+
+
+const removeAddressPrefix = function (addressString: string): string {
+  if (addressString.includes(':')) {
+    return addressString.split(':')[1]
+  }
+  return addressString
+}
+
+type NetworkSlugsType = 'ecash' | 'bitcoincash'
+
+const getAddressPrefix = function (addressString: string): NetworkSlugsType {
+  try {
+    const format = xecaddr.detectAddressFormat(addressString)
+    if (format === xecaddr.Format.Xecaddr) {
+      return 'ecash'
+    } else if (format === xecaddr.Format.Cashaddr) {
+      return 'bitcoincash'
+    }
+  } catch {
+    throw new Error("Invalid address prefix.")
+  }
+  throw new Error("Invalid address prefix.")
+}
+
+export const getAddressPrefixed = function (addressString: string): string {
+  return `${getAddressPrefix(addressString)}:${removeAddressPrefix(addressString)}`
+}
+


### PR DESCRIPTION
Related to #470

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Should solve #470 , but actually was not only `onSuccess` that wouldn't be fired, `onTransaction` would not too.  


Test plan
---
Create a PayButton or Widget with an unprefixed address and make sure it detects payments normally.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
