### PR TITLE
feat: lock editable on success

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -940,6 +940,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
                     name="Amount"
                     placeholder='Enter Amount'
                     id="userEditedAmount"
+                    disabled={success}
                   />
                  <Typography component="span">{currency}</Typography>
                 </div>


### PR DESCRIPTION
Related to #275 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Lock editable input when success


Test plan
---
make a paymente with a button with auto-close=false and make sure input is locked when success

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
