### PR TITLE
fix:shouldTriggerOnSuccess amount validate

### DIFF
--- a/react/lib/util/validate.ts
+++ b/react/lib/util/validate.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { getAddressPrefix, getCurrencyTypeFromAddress } from "./address";
 import { resolveNumber } from "./number";
 import { Currency, CurrencyObject, Transaction } from "./types";
-import { DECIMALS } from "./constants";
+import { CRYPTO_CURRENCIES, DECIMALS } from "./constants";
 
 export const shouldTriggerOnSuccess = (
     transaction: Transaction,
@@ -33,7 +33,7 @@ export const shouldTriggerOnSuccess = (
       const transactionCurrency: Currency = getCurrencyTypeFromAddress(address);
       if (transactionCurrency !== currency) {
         if (currencyObject){
-          const value = (currencyObject.float / price).toFixed(DECIMALS[transactionCurrency])
+          const value = CRYPTO_CURRENCIES.includes(currencyObject.currency) ? currencyObject.float : (currencyObject.float / price).toFixed(DECIMALS[transactionCurrency])
           isAmountValid = resolveNumber(value).isEqualTo(amount)
         }else {
           isAmountValid = false


### PR DESCRIPTION
Related to 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Small fix in shouldTriggerOnSuccess function to get the amount from currencyObject.
Sometimes we call `shouldTriggerOnSuccess` function with `currencyObject` but there is no need to convert the amount to value because the `currencyObject.currency` is crypto currency. This PR checks if `currencyObject.currency` is crypto currency and it converts amount to value only if `currencyObject.currency` is fiat. 

Test plan
---


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
