### PR TITLE
Better cashtab-connect error handling

### DIFF
--- a/react/lib/util/cashtab.ts
+++ b/react/lib/util/cashtab.ts
@@ -91,6 +91,7 @@ export const openCashtabPayment = async (bip21Url: string, fallbackUrl?: string)
       await cashtab.sendBip21(bip21Url);
     } else {
       window.open(webUrl, '_blank');
+      return;
     }
   } catch (error) {
     if (error instanceof CashtabAddressDeniedError) {


### PR DESCRIPTION
Description
---
I was running into issues w/ my Brave extensions and noticed that the fallback to using cashtab.com wasn't working. I've introduced some more robust error handling. During build, it will no longer show the warnings that we're importing but not using some of the cashtab-connect error handling.


Test plan
---
Make sure cashtab extension + .com open as appropriate when clicking "Send with Cashtab".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment flow reliability when the browser extension is unavailable or times out.
  * Ensured the app falls back to the web payment page in more error scenarios to reduce failed payments.
  * Handles user-denied address requests gracefully by stopping the flow without causing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->