### PR TITLE
fix: adjusted QR code mousedown border to prevent dialog size changing

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -375,9 +375,6 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
         padding: '1rem',
         cursor: 'pointer',
         userSelect: 'none',
-        '&:active': {
-          boxShadow: isDarkMode ? '0 0 0 2px #444' : '0 0 0 2px #ddd',
-        },
         '& path': {
           opacity: base.loading ? 0 : base.success ? 0.35 : 1,
           color: base.theme.palette.secondary,


### PR DESCRIPTION
<!-- Non-technical -->
Description
---
When clicking the QR code, it would adjust the size of every parent div including the dialog itself. This removes the 'active' QR code border, fixing that.


Test plan
---
Open a pb dialog and click on the QR code to see that the dialog does not grow by 1-2px like it does in master.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed active state styling from the QR code container.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->