### PR TITLE
fix: amount not being set correctly when using fiat value

### DIFF
--- a/react/lib/components/PayButton/PayButton.tsx
+++ b/react/lib/components/PayButton/PayButton.tsx
@@ -367,17 +367,15 @@ export const PayButton = ({
 
   useEffect(() => {
     if (currencyObj && isFiat(currency) && price) {
-      if (!convertedCurrencyObj) {
-        const addressType: Currency = getCurrencyTypeFromAddress(to);
-        const convertedObj = getCurrencyObject(
-          currencyObj.float / price,
-          addressType,
-          randomSatoshis,
-        );
-        setCryptoAmount(convertedObj.string);
-        setConvertedCurrencyObj(convertedObj);
-      }
-    } else if (!isFiat(currency) && randomSatoshis && !convertedCurrencyObj) {
+      const addressType: Currency = getCurrencyTypeFromAddress(to);
+      const convertedObj = getCurrencyObject(
+        currencyObj.float / price,
+        addressType,
+        randomSatoshis,
+      );
+      setCryptoAmount(convertedObj.string);
+      setConvertedCurrencyObj(convertedObj);
+    } else if (!isFiat(currency) && randomSatoshis) {
       const convertedObj = getCurrencyObject(
         amount as number,
         addressType,


### PR DESCRIPTION
<!-- Non-technical -->
Description
---
Amount wouldn't change even after closing the dialog and opening up a new one with a different fiat value; this fixes that.


Test plan
---
I was only able to reproduce the issue on coin.dance/support which has since been updated to use this branch... not sure how else to test the issue in master.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved currency conversion logic in the payment button. Enhanced calculation flow for both fiat and non-fiat currencies to ensure converted amounts are always recalculated directly from current values. Streamlined conditional branches to make the update process more direct, reliable, and efficient.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->