### PR TITLE
feat: allow resetting qrcode

### DIFF
--- a/react/lib/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/lib/components/PaymentDialog/PaymentDialog.tsx
@@ -67,6 +67,7 @@ export interface PaymentDialogProps extends ButtonProps {
   transactionText?: string
   convertedCurrencyObj?: CurrencyObject;
   setConvertedCurrencyObj?: Function;
+  sendAnotherText?: string;
 }
 
 export const PaymentDialog = ({
@@ -129,10 +130,12 @@ export const PaymentDialog = ({
   setConvertedCurrencyObj,
   theme: themeProp,
   donationAddress,
-  donationRate
+  donationRate,
+  sendAnotherText = 'Send Another Payment'
 }: PaymentDialogProps): React.ReactElement => {
   const [success, setSuccess] = useState(false);
   const [internalDisabled, setInternalDisabled] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
 
   // Compute auto-close delay (ms) using shared util
 
@@ -150,6 +153,12 @@ export const PaymentDialog = ({
     clearAutoCloseTimer();
     if (onClose) onClose(success, paymentId);
     setSuccess(false);
+  };
+
+  const handleSendAnother = (): void => {
+    clearAutoCloseTimer();
+    setSuccess(false);
+    setResetKey(prev => prev + 1);
   };
 
   const handleSuccess = (transaction: Transaction): void => {
@@ -259,11 +268,12 @@ export const PaymentDialog = ({
           donationRate={donationRate}
           convertedCurrencyObj={convertedCurrencyObj}
           setConvertedCurrencyObj={setConvertedCurrencyObj}
+          resetKey={resetKey}
           foot={success && (
             <ButtonComponent
-              onClick={handleWidgetClose}
-              text="Close"
-              hoverText="Close"
+              onClick={handleSendAnother}
+              text={sendAnotherText}
+              hoverText={sendAnotherText}
               disabled={internalDisabled} />
           )}        />
       </Dialog>

--- a/react/lib/components/Widget/WidgetContainer.tsx
+++ b/react/lib/components/Widget/WidgetContainer.tsx
@@ -54,6 +54,7 @@ export interface WidgetContainerProps
   donationAddress?: string
   donationRate?: number
   convertedCurrencyObj?: CurrencyObject;
+  resetKey?: number;
 }
 
 const snackbarOptionsSuccess: OptionsObject = {
@@ -138,6 +139,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       donationRate,
       convertedCurrencyObj,
       setConvertedCurrencyObj,
+      resetKey,
       ...widgetProps
     } = props;
     const [internalCurrencyObj, setInternalCurrencyObj] = useState<CurrencyObject>();
@@ -160,6 +162,13 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
     const { enqueueSnackbar } = useSnackbar();
 
     const [shiftCompleted, setShiftCompleted] = useState(false);
+
+    useEffect(() => {
+      if (resetKey !== undefined && resetKey > 0) {
+        setSuccess(false);
+        setShiftCompleted(false);
+      }
+    }, [resetKey]);
 
     const paymentClient = getAltpaymentClient()
 


### PR DESCRIPTION
Related to #280 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Implement send another payment option after a payment is complete


Test plan
---
Make a payment, click in Send Another Payment and do another payment, make sure everything works smoothly 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment dialog now includes a "Send Another Payment" option that automatically resets the form, enabling users to process multiple payments sequentially without closing and reopening the dialog.
  * "Send Another Payment" button text is now customizable through configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->