### PR TITLE
fix: altpayment overlap footer

### DIFF
--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -201,7 +201,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
 
   const SideshiftCtn = styled('div')({
     alignItems: 'center', display: 'flex', flexDirection: 'column',
-    height: 'calc(100% - 20px)', width: '100%', position: 'absolute',
+    height: 'calc(100% - 45px)', width: '100%', position: 'absolute',
     zIndex: 9, top: '0', left: '0', background: '#f5f5f7', paddingTop: '20px'
   })
 

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -417,6 +417,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
         animationDelay: '0.7s',
         opacity: 0,
         lineHeight: 2.5,
+        paddingTop: '14px',
       },
       footerSeparator: {
         marginLeft: '7px',


### PR DESCRIPTION
Related to #588 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fix footer hiding when altpayment widget appears.


Test plan
---
Click in 'Don't have any XEC?' make sure the footer remains there 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the payment widget container's vertical spacing calculations to provide a more balanced and visually optimized layout for improved user experience.
  * Enhanced the footer section styling with additional top padding to ensure improved visual alignment, consistent spacing, and better interface aesthetics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->