### PR TITLE
Generate deeplinks instead of calling Cashtab directly

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -126,6 +126,32 @@ interface StyleProps {
   copied: boolean
 }
 
+function convertBip21ToDeeplink(bip21Url: string, apiBaseUrl?: string): string | undefined {
+  if (!apiBaseUrl) {
+    return undefined
+  }
+
+  // Parse BIP21 URL: ecash:address?amount=100&opreturnraw=xxx
+  const [addressPart, queryPart] = bip21Url.split('?')
+  const params = new URLSearchParams()
+  params.set('address', addressPart)
+  
+  if (queryPart) {
+    const queryParams = new URLSearchParams(queryPart)
+    // Add all query parameters from the BIP21 string
+    queryParams.forEach((value, key) => {
+      params.set(key, value)
+    })
+  }
+  
+  // Add b=1 to the deeplink URL to indicate that the payment app should move
+  // back to the browser after the payment is complete.
+  params.set('b', '1')
+  
+  // Return absolute URL for the deeplink
+  return `${apiBaseUrl}/app?${params.toString()}`
+}
+
 export const Widget: React.FunctionComponent<WidgetProps> = props => {
   const {
     to,
@@ -946,31 +972,9 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     }
   }, [totalReceived, currency, goalAmount, price, hasPrice, contributionOffset])
 
-  const convertBip21ToDeeplink = (bip21Url: string): string => {
-    // Parse BIP21 URL: ecash:address?amount=100&opreturnraw=xxx
-    const [addressPart, queryPart] = bip21Url.split('?')
-    const params = new URLSearchParams()
-    params.set('address', addressPart)
-    
-    if (queryPart) {
-      const queryParams = new URLSearchParams(queryPart)
-      // Add all query parameters from the BIP21 string
-      queryParams.forEach((value, key) => {
-        params.set(key, value)
-      })
-    }
-    
-    // Add b=1 to the deeplink URL to indicate that the payment app should move
-    // back to the browser after the payment is complete.
-    params.set('b', '1')
-    
-    // Return absolute URL for the deeplink
-    return `https://paybutton.org/app?${params.toString()}`
-  }
-
   const handleButtonClick = async () => {
     if (thisAddressType === 'XEC') {
-      const deeplinkUrl = convertBip21ToDeeplink(url)
+      const deeplinkUrl = convertBip21ToDeeplink(url, apiBaseUrl)
       await openCashtabPayment(url, deeplinkUrl)
     } else {
       window.location.href = url

--- a/react/lib/components/Widget/WidgetContainer.tsx
+++ b/react/lib/components/Widget/WidgetContainer.tsx
@@ -2,7 +2,7 @@ import { OptionsObject, SnackbarProvider, useSnackbar } from 'notistack';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { getAltpaymentClient } from '../../altpayment';
 import { GlobalStyles } from '@mui/material'
-
+import config from '../../paybutton-config.json'
 
 import successSound from '../../assets/success.mp3.json';
 
@@ -121,7 +121,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       disabled,
       editable,
       wsBaseUrl,
-      apiBaseUrl,
+      apiBaseUrl = config.apiBaseUrl,
       successText,
       hoverText,
       disableAltpayment,


### PR DESCRIPTION
Cashtab will still be called via a redirection if no app handles the link first. This makes this code compatible with both mobile and desktop with no special case.

Works together with https://github.com/PayButton/paybutton-server/pull/1106.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deeplink support for XEC payments, enabling seamless browser-to-payment-app flow for enhanced transaction processing.
  * Deeplink generation now uses the configured API base URL by default, ensuring consistent payment routing without extra setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->