### PR TITLE
Add a fallback polling when the ws connection is lost on mobile

### DIFF
--- a/react/lib/components/Widget/WidgetContainer.tsx
+++ b/react/lib/components/Widget/WidgetContainer.tsx
@@ -19,6 +19,9 @@ import {
   shouldTriggerOnSuccess,
   isPropsTrue,
   DEFAULT_DONATION_RATE,
+  POLL_TX_HISTORY_LOOKBACK,
+  POLL_REQUEST_DELAY,
+  POLL_MAX_RETRY,
 } from '../../util';
 import { getAddressDetails } from '../../util/api-client';
 
@@ -291,7 +294,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       try {
         const history = await getAddressDetails(to, apiBaseUrl);
         // Save time by only checking the last few transactions
-        const recentTxs = history.slice(0, 5);
+        const recentTxs = history.slice(0, POLL_TX_HISTORY_LOOKBACK);
 
         recentTxs.forEach(tx => {
           handleNewTransaction(tx);
@@ -365,7 +368,8 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
 
     // Retry mechanism: check every second if payment hasn't succeeded yet
     useEffect(() => {
-      if (retryCount === 0 || success || retryCount >= 5) {
+
+      if (retryCount === 0 || success || retryCount >= POLL_MAX_RETRY) {
         // Retry up to 5 times or until the payment succeeds. If the payment tx
         // is not found within this time period, something has gone wrong.
         return;
@@ -382,7 +386,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
         
         // Increment retry count for next attempt (regardless of success/error)
         setRetryCount(prev => prev + 1);
-      }, 1000);
+      }, POLL_REQUEST_DELAY);
 
       return () => {
         clearInterval(intervalId);

--- a/react/lib/util/constants.ts
+++ b/react/lib/util/constants.ts
@@ -38,3 +38,7 @@ export const DEFAULT_MINIMUM_DONATION_AMOUNT: { [key: string]: number } = {
     BCH: 0.00001000,
     XEC: 10,
 };
+
+export const POLL_TX_HISTORY_LOOKBACK = 5 // request last 5 txs
+export const POLL_REQUEST_DELAY = 1000 // 1s
+export const POLL_MAX_RETRY = 5


### PR DESCRIPTION
It is common on mobile to move the widget to the background, which causes the DNS to fail. Other issues might also happen, including the even already being fired when the widget is back to foreground.

To cover all these use cases this commit adds a polling phase when the widget become visible (event triggered when the browser page goes to foreground on mobile). It will poll for the last 5 transactions from the history once and check if there is a matching payment tx, otherwise it retries every second for 5s which should be plenty for the tx to be discovered.

The retry stops as soon as the payment is marked successful. In practice the mobile apps (either Marlin or Cashtab) add a modal window and a small delay before returning to the browser so the retry is not needed most of the time.

This has been tested with a remote console, logs and tweaks to make sure all the scenarios are covered properly.

Note that this commit does NOT fix the existing bugs. This should be done in other commits/PRs and reference the appropriated issue. More specifically the following bugs are worked around but not fixed:
 - ~~The returned object for `getAddressDetails` does not match its interface. This needs to be dealed with on server side.~~ Now fixed by https://github.com/PayButton/paybutton-server/pull/1108 and commit 7de14ca20c1b2596e3b1a2f831bffd8a2b2003ef
 - There is no handling of the chronik ws connection closing when the browser goes to background (which cuts network on mobile). No attempt is made to reconnect the lost ws connection either, so polling takes over. (Update: #619 )
 - The `shouldTriggerOnSuccess` function doesn't filter out the payment ID when it's undefined, meaning it will match any tx that looks like the payment one but has no payment ID associated with it. This commit avoids this by exiting early and avoiding the call in this case.
 - Confirmed transactions are ignored. I have no idea why this is the case but it is consistent across the codebase, so any transaction being mined before it entered the chronik instance mempool will be missed.

Related to #616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment detection with per-attempt retry polling to confirm transactions under flaky conditions.
  * Tab visibility handling now triggers an immediate verification when you return to the app, speeding up payment confirmation.
  * Added guards to skip unnecessary checks when destination is missing or payment already succeeded.

* **Chores**
  * Introduced polling configuration to control lookback, delay, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->