### PR TITLE
Fix the widget tests expecting undefined apiBaseUrl

### DIFF
--- a/react/lib/tests/components/Widget.test.tsx
+++ b/react/lib/tests/components/Widget.test.tsx
@@ -7,6 +7,7 @@ import { TEST_ADDRESSES } from '../util/constants'
 import copyToClipboard from 'copy-to-clipboard'
 import type { Currency } from '../../util'
 import { isFiat } from '../../util';
+import config from '../../paybutton-config.json'
 
 jest.mock('copy-to-clipboard', () => jest.fn())
 
@@ -62,7 +63,7 @@ describe('Widget – standalone paymentId (crypto)', () => {
       )
 
       await waitFor(() => {
-        expect(createPayment).toHaveBeenCalledWith(5, to, undefined)
+        expect(createPayment).toHaveBeenCalledWith(5, to, config.apiBaseUrl)
       })
     }
   )
@@ -195,7 +196,7 @@ describe('Widget – standalone paymentId (crypto)', () => {
       await waitFor(() => {
         expect(createPayment).toHaveBeenCalledTimes(1)
       })
-      expect(createPayment).toHaveBeenCalledWith(undefined, to, undefined)
+      expect(createPayment).toHaveBeenCalledWith(undefined, to, config.apiBaseUrl)
     }
   )
 })
@@ -222,7 +223,7 @@ describe('Widget – standalone paymentId (fiat)', () => {
       const expectedCrypto = amount / price
 
       await waitFor(() => {
-        expect(createPayment).toHaveBeenCalledWith(expectedCrypto, to, undefined)
+        expect(createPayment).toHaveBeenCalledWith(expectedCrypto, to, config.apiBaseUrl)
       })
     }
   )


### PR DESCRIPTION
The tests have been broken by https://github.com/PayButton/paybutton/commit/bf800cc07d91df1966b6b601a4c988e8bd7da26d. The tests expects `createPayment` to be called; the apiBaseUrl is irrelevant for the tests but the params needs to be checked including this one. The above commit changed the default from undefined to whatever is set in the config so we oblige.

Test Plan:
  yarn test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations to verify that the configured API base URL is correctly passed to payment creation calls across multiple payment scenarios, including crypto and fiat pathways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->