### PR TITLE
Convert SimplifiedTransaction[] to Transaction[] type in getAddressDe…

### DIFF
--- a/react/lib/util/api-client.ts
+++ b/react/lib/util/api-client.ts
@@ -11,11 +11,10 @@ import {
 } from './types';
 import { isFiat } from './currency';
 import { CURRENCY_TYPES_MAP, DECIMALS } from './constants';
-import Decimal from 'decimal.js';
 
 interface SimplifiedTransaction {
   hash: string
-  amount: Decimal
+  amount: string
   paymentId: string
   confirmed?: boolean
   message: string
@@ -24,15 +23,15 @@ interface SimplifiedTransaction {
   rawMessage: string
   inputAddresses: Array<{
     address: string
-    amount: Decimal
+    amount: string
   }>
   outputAddresses: Array<{
     address: string
-    amount: Decimal
+    amount: string
   }>
   prices: Array<{
     price: {
-      value: Decimal
+      value: string
       quoteId: number
     }
   }>
@@ -71,7 +70,7 @@ export const getAddressDetails = async (
     };
     const transaction: Transaction = {
       hash: apiTransaction.hash,
-      amount: apiTransaction.amount.toString(),
+      amount: apiTransaction.amount,
       paymentId: apiTransaction.paymentId,
       confirmed: apiTransaction.confirmed,
       message: apiTransaction.message,

--- a/react/lib/util/api-client.ts
+++ b/react/lib/util/api-client.ts
@@ -11,6 +11,32 @@ import {
 } from './types';
 import { isFiat } from './currency';
 import { CURRENCY_TYPES_MAP, DECIMALS } from './constants';
+import Decimal from 'decimal.js';
+
+interface SimplifiedTransaction {
+  hash: string
+  amount: Decimal
+  paymentId: string
+  confirmed?: boolean
+  message: string
+  timestamp: number
+  address: string
+  rawMessage: string
+  inputAddresses: Array<{
+    address: string
+    amount: Decimal
+  }>
+  outputAddresses: Array<{
+    address: string
+    amount: Decimal
+  }>
+  prices: Array<{
+    price: {
+      value: Decimal
+      quoteId: number
+    }
+  }>
+}
 
 export const getAddressDetails = async (
   address: string,
@@ -37,8 +63,7 @@ export const getAddressDetails = async (
   }
 
   const transactions: Transaction[] = [];
-  // apiTransaction type is SimplifiedTransaction from paybutton-server/ws-service/types.ts
-  apiTransactions.forEach((apiTransaction: any) => {
+  apiTransactions.forEach((apiTransaction: SimplifiedTransaction) => {
     const opReturn = {
       rawMessage: apiTransaction.rawMessage,
       message: apiTransaction.message,
@@ -46,7 +71,7 @@ export const getAddressDetails = async (
     };
     const transaction: Transaction = {
       hash: apiTransaction.hash,
-      amount: apiTransaction.amount,
+      amount: apiTransaction.amount.toString(),
       paymentId: apiTransaction.paymentId,
       confirmed: apiTransaction.confirmed,
       message: apiTransaction.message,


### PR DESCRIPTION
…tails

The API is likely to keep evolving and maintaining the types in sync is brittle as demonstrated here. Apply a proper conversion function to ensure the format is as expected.

Test Plan:
yarn test
Check payment detection still works on mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API failures and malformed responses now return safe empty results with warnings instead of causing errors.

* **Refactor**
  * Transaction records normalized for consistent display: amounts remain strings, input addresses reduced to address-only lists, and message/payment metadata consolidated.
  * Added an opReturn field to transaction records to surface embedded message/payment data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->