### PR TITLE
feat: Updated disable-altpayments to altpayments

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -101,7 +101,7 @@ Example using JavaScript to generate a PayButton:
     disabled: false,
     wsBaseUrl: 'http://localhost:5000',
     apiBaseUrl: 'http://localhost:3000'
-    disableAltpayment: true,
+    altpayment: 'XEC',
     contributionOffset: 10,
     autoClose: true
   };
@@ -988,11 +988,11 @@ apiBaseUrl = "https://paybutton.org"
 
 <!-- tabs:end -->
 
-## disable-altpayment
+## altpayment
 
-> **The ‘disableAltpayment’ parameter disables altpayment logic.**
+> **The `altpayment` parameter controls SideShift altpayment behavior.**
 
-?> This parameter is optional. Default value is false. Possible values are true or false.
+?> This parameter is optional. When omitted or set to `true`, users see an opt-in "Don't have any XEC/BCH?" link to swap other coins via SideShift. Set to `XEC` or `BCH` to hide that link. Set to `BTC` to automatically open the SideShift flow with BTC pre-selected. Unrecognized coin tickers behave the same as `true`.
 
 **Example:**
 <!-- tabs:start -->
@@ -1000,19 +1000,19 @@ apiBaseUrl = "https://paybutton.org"
 #### ** HTML **
 
 ```html
-disable-altpayment="true"
+altpayment="BTC"
 ```
 
 #### ** JavaScript **
 
 ```javascript
-disableAltpayment: 'true'
+altpayment: 'BTC'
 ```
 
 #### ** React **
 
 ```react
-disableAltpayment = "true"
+altpayment = "BTC"
 ```
 
 <!-- tabs:end -->

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -28,7 +28,7 @@
   - [disabled](/?id=disabled)
   - [ws-base-url](/?id=ws-base-url)
   - [api-base-url](/?id=api-base-url)
-  - [disable-altpayment](/?id=disable-altpayment)
+  - [altpayment](/?id=altpayment)
   - [contribution-offset](/?id=contribution-offset)
   - [auto-close](/?id=auto-close)
   - [disable-sound](/?id=disable-sound)

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -101,7 +101,7 @@
     disabled: false,
     wsBaseUrl: 'http://localhost:5000',
     apiBaseUrl: 'http://localhost:3000'
-    disableAltpayment: true,
+    altpayment: 'XEC',
     contributionOffset: 10
   };
 
@@ -982,11 +982,11 @@ apiBaseUrl: 'https://paybutton.org'
 apiBaseUrl = "https://paybutton.org"
 ```
 <!-- tabs:end -->
-## disable-altpayment
+## altpayment
 
-> **“disableAltpayment” 参数用于禁用备用支付逻辑。**
+> **“altpayment” 参数用于控制 SideShift 备用支付行为。**
 
-?> 该参数为可选项，默认值为 false。可选值为 true 或 false。
+?> 该参数为可选项。省略或设为 `true` 时，用户会看到“没有 XEC/BCH？”的 SideShift 兑换入口。设为 `XEC` 或 `BCH` 可隐藏该入口。设为 `BTC` 将自动打开 SideShift 流程并预选 BTC。无法识别的币种代码与 `true` 行为相同。
 
 **Example:**
 <!-- tabs:start -->
@@ -994,19 +994,19 @@ apiBaseUrl = "https://paybutton.org"
 #### ** HTML **
 
 ```html
-disable-altpayment="true"
+altpayment="BTC"
 ```
 
 #### ** JavaScript **
 
 ```javascript
-disableAltpayment: 'true'
+altpayment: 'BTC'
 ```
 
 #### ** React **
 
 ```react
-disableAltpayment = "true"
+altpayment = "BTC"
 ```
 <!-- tabs:end -->
 

--- a/docs/zh-cn/_sidebar.md
+++ b/docs/zh-cn/_sidebar.md
@@ -27,7 +27,7 @@
   - [disabled](/zh-cn/?id=disabled)
   - [ws-base-url](/zh-cn/?id=ws-base-url)
   - [api-base-url](/zh-cn/?id=api-base-url)
-  - [disable-altpayment](/zh-cn/?id=disable-altpayment)
+  - [altpayment](/zh-cn/?id=altpayment)
   - [contribution-offset](/zh-cn/?id=contribution-offset)
   - [auto-close](/zh-cn/?id=auto-close)
   - [disable-sound](/zh-cn/?id=disable-sound)

--- a/docs/zh-tw/README.md
+++ b/docs/zh-tw/README.md
@@ -101,7 +101,7 @@
     disabled: false,
     wsBaseUrl: 'http://localhost:5000',
     apiBaseUrl: 'http://localhost:3000'
-    disableAltpayment: true,
+    altpayment: 'XEC',
     contributionOffset: 10
   };
 
@@ -982,11 +982,11 @@ apiBaseUrl: 'https://paybutton.org'
 apiBaseUrl = "https://paybutton.org"
 ```
 
-## disable-altpayment
+## altpayment
 
-> **“disableAltpayment” 參數用於禁用備用支付邏輯。**
+> **「altpayment」參數用於控制 SideShift 備用支付行為。**
 
-?> 該參數為可選項，預設值為 false。可選值為 true 或 false。
+?> 該參數為可選項。省略或設為 `true` 時，使用者會看到「沒有 XEC/BCH？」的 SideShift 兌換入口。設為 `XEC` 或 `BCH` 可隱藏該入口。設為 `BTC` 將自動開啟 SideShift 流程並預選 BTC。無法識別的幣種代碼與 `true` 行為相同。
 
 **Example:**
 <!-- tabs:start -->
@@ -994,19 +994,19 @@ apiBaseUrl = "https://paybutton.org"
 #### ** HTML **
 
 ```html
-disable-altpayment="true"
+altpayment="BTC"
 ```
 
 #### ** JavaScript **
 
 ```javascript
-disableAltpayment: 'true'
+altpayment: 'BTC'
 ```
 
 #### ** React **
 
 ```react
-disableAltpayment = "true"
+altpayment = "BTC"
 ```
 <!-- tabs:end -->
 

--- a/docs/zh-tw/_sidebar.md
+++ b/docs/zh-tw/_sidebar.md
@@ -27,7 +27,7 @@
   - [disabled](/zh-tw/?id=disabled)
   - [ws-base-url](/zh-tw/?id=ws-base-url)
   - [api-base-url](/zh-tw/?id=api-base-url)
-  - [disable-altpayment](/zh-tw/?id=disable-altpayment)
+  - [altpayment](/zh-tw/?id=altpayment)
   - [contribution-offset](/zh-tw/?id=contribution-offset)
   - [auto-close](/zh-tw/?id=auto-close)
   - [disable-sound](/zh-tw/?id=disable-sound)

--- a/paybutton/dev/demo/index.html
+++ b/paybutton/dev/demo/index.html
@@ -40,6 +40,10 @@
     <div class="paybutton" to="ecash:qp2v7kemclu7mv5y3h9qprwp0mrevkqt9gprvmm7yl" goal-amount="2500.05" currency="USD"
       text="Donate (other dev)" on-success="mySuccessFunction" on-transaction="myTransactionFunction" altpayment="true"></div>
 
+    <div class="paybutton" to="ecash:qp2v7kemclu7mv5y3h9qprwp0mrevkqt9gprvmm7yl" amount="15" currency="USD"
+      text="Pay with BTC" on-success="mySuccessFunction" on-transaction="myTransactionFunction" altpayment="BTC"
+      theme='{ "palette": { "primary": "#F18F01", "secondary": "#ffffff", "tertiary": "#333333"} }'></div>
+
     <div class="paybutton" to="ecash:qp2v7kemclu7mv5y3h9qprwp0mrevkqt9gprvmm7yl" goal-amount="2500000.05"
       on-close="myClose" on-open="myOpen" amount="50" currency="USD" text="Random Sats" random-satoshis="true"
       theme='{ "palette": { "tertiary": "#333333"} }'></div>

--- a/paybutton/dev/demo/index.html
+++ b/paybutton/dev/demo/index.html
@@ -38,7 +38,7 @@
       currency="BCH" text="Purchase" on-transaction="myTransactionFunction" size="xl"></div>
 
     <div class="paybutton" to="ecash:qp2v7kemclu7mv5y3h9qprwp0mrevkqt9gprvmm7yl" goal-amount="2500.05" currency="USD"
-      text="Donate (other dev)" on-success="mySuccessFunction" on-transaction="myTransactionFunction" disable-altpayment="false"></div>
+      text="Donate (other dev)" on-success="mySuccessFunction" on-transaction="myTransactionFunction" altpayment="true"></div>
 
     <div class="paybutton" to="ecash:qp2v7kemclu7mv5y3h9qprwp0mrevkqt9gprvmm7yl" goal-amount="2500000.05"
       on-close="myClose" on-open="myOpen" amount="50" currency="USD" text="Random Sats" random-satoshis="true"
@@ -87,7 +87,7 @@
       <div id="the_widget" class="paybutton-widget" to="ecash:qp2v7kemclu7mv5y3h9qprwp0mrevkqt9gprvmm7yl"
         goal-amount="500000" hover-text="BLARG" amount="1000.69" success-text="WOW!" text="Purchase"
         on-success="mySuccessFunction" editable="true" on-transaction="myTransactionFunction"
-        theme='{ "palette": { "primary": "#F18F01", "secondary": "#C3F3FD", "tertiary": "#2E4057"} }' disable-altpayment="true"></div>
+        theme='{ "palette": { "primary": "#F18F01", "secondary": "#C3F3FD", "tertiary": "#2E4057"} }' altpayment="XEC"></div>
       <div class="btn">
         <button onclick="buttonClick()">Switch up widget!</button>
       </div>

--- a/paybutton/dev/demo/paybutton-generator.html
+++ b/paybutton/dev/demo/paybutton-generator.html
@@ -170,10 +170,14 @@
                 false-value="false">
               <label for="random-satoshis">Random Satoshis</label>
             </div>
-            <div class="form-input toggle">
-              <input type="checkbox" id="disable-altpayment" v-model="paybuttonProps.disableAltpayment" true-value="true"
-                false-value="false">
-              <label for="disable-altpayment">Disable Altpayment</label>
+            <div class="form-input">
+              <label for="altpayment">Altpayment</label>
+              <select id="altpayment" v-model="paybuttonProps.altpayment">
+                <option value="true">true (show link)</option>
+                <option value="XEC">XEC (hide link)</option>
+                <option value="BCH">BCH (hide link)</option>
+                <option value="BTC">BTC (auto-start)</option>
+              </select>
             </div>
             <div class="form-input toggle">
               <input type="checkbox" id="hide-send-button" v-model="paybuttonProps.hideSendButton" true-value="true"
@@ -232,7 +236,7 @@
             :disabled="paybuttonProps.disabled"
             :on-success="mySuccessFuction"
             :on-transaction="myTransactionFuction"
-            :disable-altpayment="paybuttonProps.disableAltpayment"
+            :altpayment="paybuttonProps.altpayment"
             :hide-send-button="paybuttonProps.hideSendButton"
             :transaction-text="paybuttonProps.transactionText"
             :auto-close="paybuttonProps.autoClose"
@@ -265,7 +269,7 @@
             randomSatoshis: false,
             hideToasts: false,
             disableEnforceFocus: false,
-            disableAltpayment: false,
+            altpayment: 'true',
             hideSendButton: false,
             contributionOffset: undefined,
             opReturn:undefined,

--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -100,7 +100,7 @@ const allowedProps = [
   'editable',
   'wsBaseUrl',
   'apiBaseUrl',
-  'disableAltpayment',
+  'altpayment',
   'contributionOffset',
   'autoClose',
   'disableSound',

--- a/react/lib/components/PayButton/PayButton.tsx
+++ b/react/lib/components/PayButton/PayButton.tsx
@@ -20,7 +20,8 @@ import {
   CryptoCurrency,
   ButtonSize,
   DEFAULT_DONATION_RATE,
-  createPayment
+  createPayment,
+  parseAltpayment,
 } from '../../util';
 import { PaymentDialog } from '../PaymentDialog';
 import { AltpaymentCoin, AltpaymentError, AltpaymentPair, AltpaymentShift } from '../../altpayment';
@@ -53,7 +54,7 @@ export interface PayButtonProps extends ButtonProps {
   transactionText?: string;
   disableSound?: boolean;
   autoClose?: boolean | number | string;
-  disableAltpayment?:boolean
+  altpayment?: string | boolean
   contributionOffset?:number
   hideSendButton?: boolean;
   size?: ButtonSize;
@@ -88,7 +89,7 @@ export const PayButton = ({
   transactionText,
   disableSound,
   autoClose = false,
-  disableAltpayment,
+  altpayment,
   contributionOffset,
   hideSendButton,
   size = 'md',
@@ -102,7 +103,7 @@ export const PayButton = ({
   const [amount, setAmount] = useState(initialAmount);
   const [txsSocket, setTxsSocket] = useState<Socket | undefined>(undefined);
   const [altpaymentSocket, setAltpaymentSocket] = useState<Socket | undefined>(undefined);
-  const [useAltpayment, setUseAltpayment] = useState(false);
+  const [useAltpayment, setUseAltpayment] = useState(() => parseAltpayment(altpayment).autoStart);
   const [coins, setCoins] = useState<AltpaymentCoin[]>([]);
   const [loadingPair, setLoadingPair] = useState<boolean>(false);
   const [coinPair, setCoinPair] = useState<AltpaymentPair | undefined>();
@@ -124,8 +125,19 @@ export const PayButton = ({
     getCurrencyTypeFromAddress(to),
   );
 
+  const altpaymentSocketRef = useRef<Socket | undefined>(undefined);
 
+  useEffect(() => {
+    altpaymentSocketRef.current = altpaymentSocket;
+  }, [altpaymentSocket]);
 
+  const disconnectAltpaymentSocket = useCallback(() => {
+    if (altpaymentSocketRef.current !== undefined) {
+      altpaymentSocketRef.current.disconnect();
+      altpaymentSocketRef.current = undefined;
+    }
+    setAltpaymentSocket(undefined);
+  }, []);
   useEffect(() => {
     priceRef.current = price;
   }, [price]);
@@ -251,10 +263,27 @@ export const PayButton = ({
   }, []);
 
 
+  const resetAltpaymentState = useCallback(() => {
+    setUseAltpayment(parseAltpayment(altpayment).autoStart);
+    setCoins([]);
+    setCoinPair(undefined);
+    setLoadingPair(false);
+    setLoadingShift(false);
+    setAltpaymentShift(undefined);
+    setAltpaymentError(undefined);
+    disconnectAltpaymentSocket();
+  }, [altpayment, disconnectAltpaymentSocket]);
+
   const handleCloseDialog = (success?: boolean, paymentId?: string): void => {
     if (onClose !== undefined) onClose(success, paymentId);
     setDialogOpen(false);
   };
+
+  useEffect(() => {
+    if (!dialogOpen) {
+      resetAltpaymentState();
+    }
+  }, [dialogOpen, resetAltpaymentState]);
 
   useEffect(() => {
     setAmount(initialAmount);
@@ -288,56 +317,66 @@ export const PayButton = ({
   }, [to]);
 
   useEffect(() => {
-    if (dialogOpen === false) {
-      return
+    if (!dialogOpen) {
+      return;
     }
+
+    let cancelled = false;
+
     (async () => {
-    if (txsSocket === undefined) {
-      const expectedAmount = currencyObj ? currencyObj?.float : undefined
-      await setupChronikWebSocket({
-        address: to,
-        txsSocket,
-        apiBaseUrl,
-        wsBaseUrl,
-        setTxsSocket,
-        setNewTxs,
-        setDialogOpen,
-        checkSuccessInfo: {
-          currency,
-          price,
-          randomSatoshis: randomSatoshis ?? false,
-          disablePaymentId,
-          expectedAmount,
-          expectedOpReturn: opReturn,
-          expectedPaymentId: paymentId,
-          currencyObj,
-          donationRate
+      if (txsSocket === undefined) {
+        const expectedAmount = currencyObj ? currencyObj?.float : undefined
+        await setupChronikWebSocket({
+          address: to,
+          txsSocket,
+          apiBaseUrl,
+          wsBaseUrl,
+          setTxsSocket,
+          setNewTxs,
+          setDialogOpen,
+          checkSuccessInfo: {
+            currency,
+            price,
+            randomSatoshis: randomSatoshis ?? false,
+            disablePaymentId,
+            expectedAmount,
+            expectedOpReturn: opReturn,
+            expectedPaymentId: paymentId,
+            currencyObj,
+            donationRate
+          }
+        })
+      }
+      if (cancelled || !useAltpayment) {
+        return
+      }
+      if (altpaymentSocketRef.current === undefined) {
+        await setupAltpaymentSocket({
+          addressType,
+          altpaymentSocket: altpaymentSocketRef.current,
+          wsBaseUrl,
+          setAltpaymentSocket: (socket: Socket | undefined) => {
+            altpaymentSocketRef.current = socket
+            setAltpaymentSocket(socket)
+          },
+          setCoins,
+          setCoinPair,
+          setLoadingPair,
+          setAltpaymentShift,
+          setLoadingShift,
+          setAltpaymentError,
+        })
+        if (cancelled) {
+          disconnectAltpaymentSocket()
         }
-      })
-    }
-    if (altpaymentSocket === undefined && useAltpayment) {
-      await setupAltpaymentSocket({
-        addressType,
-        altpaymentSocket,
-        wsBaseUrl,
-        setAltpaymentSocket,
-        setCoins,
-        setCoinPair,
-        setLoadingPair,
-        setAltpaymentShift,
-        setLoadingShift,
-        setAltpaymentError,
-      })
-    }
+      }
     })()
 
     return () => {
-      if (altpaymentSocket !== undefined) {
-        altpaymentSocket.disconnect();
-        setAltpaymentSocket(undefined);
-      }
+      cancelled = true
+      disconnectAltpaymentSocket()
     }
-  }, [dialogOpen, useAltpayment]);
+  }, [dialogOpen, useAltpayment, disconnectAltpaymentSocket]);
 
   useEffect(() => {
     if (initialAmount != null && currency) {
@@ -435,7 +474,7 @@ export const PayButton = ({
         wsBaseUrl={wsBaseUrl}
         apiBaseUrl={apiBaseUrl}
         hoverText={hoverText}
-        disableAltpayment={disableAltpayment}
+        altpayment={altpayment}
         contributionOffset={contributionOffset}
         hideSendButton={hideSendButton}
         autoClose={autoClose}

--- a/react/lib/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/lib/components/PaymentDialog/PaymentDialog.tsx
@@ -36,7 +36,7 @@ export interface PaymentDialogProps extends ButtonProps {
   onTransaction?: (transaction: Transaction) => void;
   wsBaseUrl?: string;
   apiBaseUrl?: string;
-  disableAltpayment?: boolean;
+  altpayment?: string | boolean;
   contributionOffset?: number;
   hideSendButton?: boolean;
   useAltpayment: boolean
@@ -98,7 +98,7 @@ export const PaymentDialog = ({
   wsBaseUrl,
   apiBaseUrl,
   hoverText,
-  disableAltpayment,
+  altpayment,
   contributionOffset,
   hideSendButton,
   autoClose = true,
@@ -231,7 +231,7 @@ export const PaymentDialog = ({
           wsBaseUrl={wsBaseUrl}
           apiBaseUrl={apiBaseUrl}
           hoverText={hoverText}
-          disableAltpayment={disableAltpayment}
+          altpayment={altpayment}
           contributionOffset={contributionOffset}
           hideSendButton={hideSendButton}
           useAltpayment={useAltpayment}

--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -1,5 +1,5 @@
-import React, { Fragment, useEffect, useState } from 'react'
-import { TextField, Select, MenuItem, InputLabel, FormControl  } from '@mui/material'
+import React, { Fragment, useEffect, useRef, useState } from 'react'
+import { TextField, Select, MenuItem, InputLabel, FormControl, Box, CircularProgress } from '@mui/material'
 import { styled } from '@mui/material/styles'
 
 import { resolveNumber, CryptoCurrency, DECIMALS } from '../../util'
@@ -25,6 +25,7 @@ interface AltpaymentProps {
   coinPair?: AltpaymentPair;
   setCoinPair: Function;
   altpaymentEditable: boolean;
+  preselectedCoin?: string;
   animation?: animation;
   addressType: CryptoCurrency;
   to: string;
@@ -49,6 +50,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
     coinPair,
     setCoinPair,
     altpaymentEditable,
+    preselectedCoin,
     animation,
     addressType,
     thisAmount,
@@ -65,6 +67,65 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
   const [selectedCoinNetwork, setSelectedCoinNetwork] = useState<string | undefined>(undefined);
   const [pairAmountFixedDecimals, setPairAmountFixedDecimals] = useState<string | undefined>(undefined);
   const [pairAmount, setPairAmount] = useState<string | undefined>(undefined);
+  const autoRateRequestedRef = useRef(false);
+  const autoQuoteRequestedRef = useRef(false);
+  const prevAltpaymentSocketRef = useRef<Socket | undefined>(undefined);
+
+  const getDepositDecimals = (
+    coin: AltpaymentCoin,
+    network: string,
+    pair: AltpaymentPair,
+  ): number => {
+    const networkTokenDetails = coin.tokenDetails?.[network]
+    if (networkTokenDetails?.decimals !== undefined) {
+      return networkTokenDetails.decimals
+    }
+    const minFraction = pair.min.split('.')[1]
+    if (minFraction !== undefined) {
+      return minFraction.length
+    }
+    return DECIMALS[coin.coin] ?? 8
+  }
+
+  const computeDepositAmountFromSettle = (): string | undefined => {
+    if (!coinPair || !selectedCoin || !selectedCoinNetwork || thisAmount == null || thisAmount === '') {
+      return undefined
+    }
+    const settleAmount = +thisAmount
+    if (Number.isNaN(settleAmount) || settleAmount <= 0) {
+      return undefined
+    }
+    const decimals = getDepositDecimals(selectedCoin, selectedCoinNetwork, coinPair)
+    return resolveNumber(settleAmount / +coinPair.rate).toFixed(decimals)
+  }
+
+  useEffect(() => {
+    if (altpaymentSocket === undefined) {
+      autoRateRequestedRef.current = false
+      autoQuoteRequestedRef.current = false
+      prevAltpaymentSocketRef.current = undefined
+      return
+    }
+    if (altpaymentSocket !== prevAltpaymentSocketRef.current) {
+      autoRateRequestedRef.current = false
+      autoQuoteRequestedRef.current = false
+      setSelectedCoin(undefined)
+      setSelectedCoinNetwork(undefined)
+      setPairAmount(undefined)
+      setPairAmountFixedDecimals(undefined)
+      prevAltpaymentSocketRef.current = altpaymentSocket
+    }
+  }, [altpaymentSocket])
+
+  useEffect(() => {
+    if (preselectedCoin && coins.length > 0 && selectedCoin === undefined) {
+      const coin = coins.find(c => c.coin === preselectedCoin)
+      if (coin) {
+        setSelectedCoin(coin)
+        setSelectedCoinNetwork(coin.networks[0])
+      }
+    }
+  }, [coins, preselectedCoin, selectedCoin])
 
   useEffect(() => {
     if (pairAmount && coinPair) {
@@ -83,36 +144,61 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
   }, [selectedCoin])
 
   useEffect(() => {
-    if (coinPair && thisAmount && selectedCoin && selectedCoinNetwork) {
-      const bigNumber = resolveNumber(+thisAmount / +coinPair.rate)
-      const tokenDetails = selectedCoin.tokenDetails
-      let decimals: number
-      if (tokenDetails !== undefined) {
-        decimals = tokenDetails[selectedCoinNetwork].decimals
-      } else {
-        decimals = coinPair.min.split('.')[1].length
+    if (coinPair && thisAmount != null && thisAmount !== '' && selectedCoin && selectedCoinNetwork) {
+      const depositAmount = computeDepositAmountFromSettle()
+      if (depositAmount === undefined) {
+        return
+      }
+      const decimals = getDepositDecimals(selectedCoin, selectedCoinNetwork, coinPair)
+      setPairAmountFixedDecimals(depositAmount)
+      if (!altpaymentEditable) {
+        setPairAmount(depositAmount)
       }
 
-      const amountString = bigNumber.toFixed(decimals)
-      setPairAmountFixedDecimals(amountString)
-
-      // Besides decimals, account for the non-decimal part of the bigNumber
-      // plus the '.' character.
-      const floorAmount = pairAmount ? Math.floor(+pairAmount) : 1
+      const floorAmount = Math.floor(+depositAmount) || 1
       const nonDecimalCharCount = 1 + Math.ceil(Math.log10(floorAmount + 1))
       setPairAmountMaxLength(nonDecimalCharCount + decimals)
     }
-  }, [coinPair, selectedCoin, thisAmount, pairAmount, selectedCoinNetwork])
+  }, [coinPair, selectedCoin, thisAmount, selectedCoinNetwork, altpaymentEditable])
 
   const requestPairRate = (): void => {
-    if (selectedCoin !== undefined) {
-      const from = `${selectedCoin.coin}-${selectedCoin?.networks[0]}`
+    if (selectedCoin !== undefined && selectedCoinNetwork !== undefined) {
+      const from = `${selectedCoin.coin}-${selectedCoinNetwork}`
       const to = addressType === 'XEC' ? `ecash-mainnet` : `bitcoincash-mainnet`
       if (altpaymentSocket !== undefined) {
         altpaymentSocket.emit('get-altpayment-rate', {from, to})
       }
     }
   }
+
+  useEffect(() => {
+    if (
+      preselectedCoin &&
+      !altpaymentEditable &&
+      selectedCoin !== undefined &&
+      selectedCoinNetwork !== undefined &&
+      coinPair === undefined &&
+      !loadingPair &&
+      !autoRateRequestedRef.current &&
+      altpaymentSocket !== undefined
+    ) {
+      autoRateRequestedRef.current = true
+      setLoadingPair(true)
+      const from = `${selectedCoin.coin}-${selectedCoinNetwork}`
+      const to = addressType === 'XEC' ? `ecash-mainnet` : `bitcoincash-mainnet`
+      altpaymentSocket.emit('get-altpayment-rate', {from, to})
+    }
+  }, [
+    preselectedCoin,
+    altpaymentEditable,
+    selectedCoin,
+    selectedCoinNetwork,
+    coinPair,
+    loadingPair,
+    altpaymentSocket,
+    addressType,
+    setLoadingPair,
+  ])
 
   const handleCoinChange = async (e: React.ChangeEvent<{ name?: string; value: unknown }>) => {
     const coinName = e.target.value as string
@@ -147,24 +233,81 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
     }
   };
 
-  const handleCreateQuoteButtonClick = () => {
-    if (altpaymentSocket !== undefined && selectedCoin !== undefined) {
-      setLoadingShift(true)
-      altpaymentSocket.emit('create-altpayment-quote', {
-        depositAmount: pairAmountFixedDecimals,
-        settleCoin:  addressType,
-        depositCoin: selectedCoin?.coin,
-        depositNetwork: selectedCoinNetwork,
-        settleAddress: to
-      });
+  const createQuote = (): boolean => {
+    if (altpaymentSocket === undefined || selectedCoin === undefined || selectedCoinNetwork === undefined) {
+      return false
     }
+
+    const depositAmount = altpaymentEditable
+      ? pairAmountFixedDecimals
+      : (pairAmountFixedDecimals ?? computeDepositAmountFromSettle())
+
+    const quotePayload: Record<string, string> = {
+      settleCoin: addressType,
+      depositCoin: selectedCoin.coin,
+      depositNetwork: selectedCoinNetwork,
+      settleAddress: to,
+    }
+
+    if (depositAmount) {
+      quotePayload.depositAmount = depositAmount
+    } else if (thisAmount != null && thisAmount !== '' && !altpaymentEditable) {
+      const settleDecimals = DECIMALS[addressType] ?? 2
+      quotePayload.settleAmount = resolveNumber(+thisAmount).toFixed(settleDecimals)
+    } else {
+      return false
+    }
+
+    setLoadingShift(true)
+    altpaymentSocket.emit('create-altpayment-quote', quotePayload)
+    return true
+  }
+
+  useEffect(() => {
+    if (
+      !preselectedCoin ||
+      altpaymentEditable ||
+      altpaymentSocket === undefined ||
+      selectedCoin === undefined ||
+      selectedCoinNetwork === undefined ||
+      coinPair === undefined ||
+      altpaymentShift !== undefined ||
+      loadingShift ||
+      autoQuoteRequestedRef.current ||
+      altpaymentError
+    ) {
+      return
+    }
+
+    autoQuoteRequestedRef.current = createQuote()
+  }, [
+    preselectedCoin,
+    altpaymentEditable,
+    altpaymentSocket,
+    selectedCoin,
+    selectedCoinNetwork,
+    coinPair,
+    altpaymentShift,
+    loadingShift,
+    altpaymentError,
+    thisAmount,
+    pairAmountFixedDecimals,
+  ])
+
+  const handleCreateQuoteButtonClick = () => {
+    createQuote()
   }
 
   const resetTrade = () => {
+    autoRateRequestedRef.current = false
+    autoQuoteRequestedRef.current = false
+    setSelectedCoin(undefined)
+    setSelectedCoinNetwork(undefined)
     setCoinPair(undefined)
     setAltpaymentError(undefined)
     setAltpaymentShift(undefined)
     setPairAmount(undefined)
+    setPairAmountFixedDecimals(undefined)
     setShiftCompleted(false)
   }
 
@@ -200,9 +343,34 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
   };
 
   const SideshiftCtn = styled('div')({
-    alignItems: 'center', display: 'flex', flexDirection: 'column',
-    height: 'calc(100% - 45px)', width: '100%', position: 'absolute',
-    zIndex: 9, top: '0', left: '0', background: '#f5f5f7', paddingTop: '20px'
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    display: 'flex',
+    flexDirection: 'column',
+    boxSizing: 'border-box',
+    position: 'absolute',
+    zIndex: 9,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: '#f5f5f7',
+    overflowY: 'auto',
+    padding: '24px',
+  })
+
+  const LoadingCenter = styled('div')({
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '16px',
+    textAlign: 'center',
+    width: 'max-content',
+    maxWidth: '100%',
   })
 
   const Header = styled('div')({
@@ -295,6 +463,26 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
     return coinString;
   }
 
+  const isAutoStart = Boolean(preselectedCoin)
+  const isAutoStartLoading = isAutoStart && !altpaymentShift && !altpaymentError
+
+  const renderLoading = (message: string) => (
+    <LoadingCenter>
+      <CircularProgress size={48} thickness={4} sx={{ display: 'block' }} />
+      <Box
+        component="span"
+        sx={{
+          fontSize: '0.9rem',
+          color: 'rgb(35, 31, 32)',
+          fontFamily: 'inherit',
+          textAlign: 'center',
+        }}
+      >
+        {message}
+      </Box>
+    </LoadingCenter>
+  )
+
   return (
     <SideshiftCtn>
       {altpaymentError ? (
@@ -302,6 +490,8 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
           <ErrorMsg>Error: {altpaymentError.errorMessage}</ErrorMsg>
           <BackLink onClick={resetTrade}>Back</BackLink>
         </Fragment>
+      ) : isAutoStartLoading ? (
+        renderLoading('Loading SideShift...')
       ) : (
         <Fragment>
           {
@@ -352,13 +542,13 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                 </ShiftReady>
               )
             ) : loadingShift ? (
-              <p>Loading Shift...</p>
-            ) : coinPair ? (
+              renderLoading('Loading Shift...')
+            ) : coinPair && selectedCoin ? (
               <Fragment>
                 <p>
                   {' '}
-                  1 {selectedCoin?.name} ~={' '}
-                  {resolveNumber(coinPair.rate).toFixed(DECIMALS[coinPair.settleCoin])} {coinPair.settleCoin}{' '}
+                  1 {selectedCoin.name} ~={' '}
+                  {resolveNumber(coinPair.rate).toFixed(DECIMALS[coinPair.settleCoin] ?? 8)} {coinPair.settleCoin}{' '}
                 </p>
                 {altpaymentEditable ? (
                   <div style={{ display: 'flex', justifyContent: 'center', margin: '6px auto', width: '100%' }}>
@@ -383,29 +573,30 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                     !isAboveMinimumAltpaymentAmount ||
                     !isBelowMaximumAltpaymentAmount ? {opacity: '0.5', cursor: 'not-allowed'} : {}}>
                 <Button
-                  text={`Send ${selectedCoin?.name}`}
-                  hoverText={`Send ${selectedCoin?.name}`}
+                  text={`Send ${selectedCoin.name}`}
+                  hoverText={`Send ${selectedCoin.name}`}
                   onClick={handleCreateQuoteButtonClick}
                   disabled={
                     loadingPair ||
                     selectedCoinNetwork === undefined ||
                     (altpaymentEditable && !pairAmount) ||
+                    (!altpaymentEditable && !pairAmountFixedDecimals && !computeDepositAmountFromSettle()) ||
                     !isAboveMinimumAltpaymentAmount ||
                     !isBelowMaximumAltpaymentAmount
                   }
                   animation={animation}
                 />
                 </div>
-                {!isAboveMinimumAltpaymentAmount && (
+                {pairAmount && !isAboveMinimumAltpaymentAmount && (
                   <AmountError>Amount is below minimum.</AmountError>
                 )}
-                {!isBelowMaximumAltpaymentAmount && (
+                {pairAmount && !isBelowMaximumAltpaymentAmount && (
                   <AmountError>Amount is above maximum.</AmountError>
                 )}
               </Fragment>
             ) : (
               <Fragment>
-                {coins.length === 0 && <div>Loading...</div>}
+                {coins.length === 0 && renderLoading('Loading SideShift...')}
                 {coins.length > 0 && (
                   <Fragment>
                     <Header>
@@ -414,6 +605,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                         <img src={sideShiftLogo} alt='SideShift' />
                       </a>
                     </Header>
+                    {!preselectedCoin ? (
                     <FormControl>
                       <InputLabel id="select-coin-label">Select a coin</InputLabel>
                       <SelectBox
@@ -438,6 +630,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                         ))}
                       </SelectBox>
                     </FormControl>
+                    ) : null}
 
                     <Spacer />
                     {selectedCoin && selectedCoin.networks.length > 1 && (
@@ -490,9 +683,6 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
             )
             // END: Altpayment region
           }
-           {coinPair && !loadingShift && (
-              <BackLink onClick={resetTrade}>Back</BackLink>
-            )}
         </Fragment>
       )}
     </SideshiftCtn>

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -1188,7 +1188,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
           {thisUseAltpayment ? (
             <AltpaymentWidget
               altpaymentSocket={thisAltpaymentSocket}
-              thisAmount={thisAmount}
+              thisAmount={isFiat(currency) && convertedCryptoAmount !== undefined ? convertedCryptoAmount : thisAmount}
               updateAmount={updateAmount}
               setUseAltpayment={setThisUseAltpayment}
               altpaymentShift={thisAltpaymentShift}

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -38,6 +38,7 @@ import {
   isPropsTrue,
   setupChronikWebSocket,
   setupAltpaymentSocket,
+  parseAltpayment,
   CryptoCurrency,
   DEFAULT_DONATION_RATE,
   DEFAULT_MINIMUM_DONATION_AMOUNT,
@@ -86,7 +87,7 @@ export interface WidgetProps {
   apiBaseUrl?: string
   loading?: boolean
   hoverText?: string
-  disableAltpayment?: boolean
+  altpayment?: string | boolean
   contributionOffset?: number
   setAltpaymentShift?: Function
   altpaymentShift?: AltpaymentShift | undefined
@@ -178,7 +179,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     altpaymentShift,
     shiftCompleted,
     setShiftCompleted,
-    disableAltpayment,
+    altpayment,
     contributionOffset,
     useAltpayment,
     setUseAltpayment,
@@ -251,7 +252,9 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     (setAltpaymentShift as ((s: AltpaymentShift | undefined) => void) | undefined) ??
     setInternalAltpaymentShift
 
-  const [internalUseAltpayment, setInternalUseAltpayment] = useState<boolean>(false)
+  const [internalUseAltpayment, setInternalUseAltpayment] = useState<boolean>(
+    () => parseAltpayment(altpayment).autoStart
+  )
   const thisUseAltpayment = useAltpayment ?? internalUseAltpayment
   const setThisUseAltpayment =
     (setUseAltpayment as ((b: boolean) => void) | undefined) ?? setInternalUseAltpayment
@@ -305,6 +308,8 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   const [goalText, setGoalText] = useState('')
   const [goalPercent, setGoalPercent] = useState(0)
   const [altpaymentEditable, setAltpaymentEditable] = useState<boolean>(false)
+
+  const altpaymentConfig = useMemo(() => parseAltpayment(altpayment), [altpayment])
 
   const price = props.price ?? 0
   const [hasPrice, setHasPrice] = useState(props.price !== undefined && props.price > 0)
@@ -1138,12 +1143,20 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   return (
     <ThemeProvider value={theme}>
       <Box
-        sx={classes.root}
+        sx={{
+          ...classes.root,
+          ...(thisUseAltpayment ? {
+            minWidth: 340,
+            width: 340,
+            minHeight: 520,
+          } : {}),
+        }}
         pt={0}
         display="flex"
         flexDirection="column"
         alignItems="center"
       >
+        {!thisUseAltpayment ? (
         <Box
           flex="shrink"
           alignSelf="stretch"
@@ -1161,14 +1174,16 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
             })()}
           </Typography>
         </Box>
+        ) : null}
 
         <Box
           display="flex"
           flexDirection="column"
           alignItems="center"
-          px={3}
-          pt={2}
+          px={thisUseAltpayment ? 0 : 3}
+          pt={thisUseAltpayment ? 0 : 2}
           position="relative"
+          sx={thisUseAltpayment ? { minHeight: 480, flex: 1, alignSelf: 'stretch', width: '100%' } : undefined}
         >
           {thisUseAltpayment ? (
             <AltpaymentWidget
@@ -1190,12 +1205,14 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
               coinPair={thisCoinPair}
               setCoinPair={setThisCoinPair}
               altpaymentEditable={altpaymentEditable}
+              preselectedCoin={altpaymentConfig.preselectedCoin}
               animation={animation}
               addressType={thisAddressType}
               to={to}
             />
           ) : null}
 
+          {!thisUseAltpayment ? (
           <Fragment>
             {loading && shouldDisplayGoal ? (
               <Typography
@@ -1365,7 +1382,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
               </Box>
             )}
 
-            {!isPropsTrue(disableAltpayment) ? (
+            {altpaymentConfig.showAltpaymentLink && !thisUseAltpayment ? (
               <Typography
                 component="div"
                 sx={mergeSx(
@@ -1390,18 +1407,23 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
               </Typography>
             ) : null}
           </Fragment>
+          ) : null}
 
           {foot ? (
             <Box pt={2} flex={1 as any}>
               {foot as any}
             </Box>
           ) : null}
+        </Box>
 
-          <Box py={0.8}>
-            <Typography component="div" sx={classes.footer}>
+        <Box py={0.8} alignSelf="stretch" width="100%">
+          <Typography component="div" sx={classes.footer}>
               <Box>Powered by PayButton.org</Box>
 
               {(() => {
+                if (thisUseAltpayment) {
+                  return false
+                }
                 // For fiat conversions, check the converted crypto amount
                 // For crypto-only, check the currency object amount
                 const amountToCheck = hasPrice && convertedCryptoAmount !== undefined
@@ -1497,7 +1519,6 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
                 </>
               ) : null}
             </Typography>
-          </Box>
         </Box>
       </Box>
     </ThemeProvider>

--- a/react/lib/components/Widget/WidgetContainer.tsx
+++ b/react/lib/components/Widget/WidgetContainer.tsx
@@ -49,7 +49,7 @@ export interface WidgetContainerProps
   wsBaseUrl?: string;
   apiBaseUrl?: string;
   successText?: string;
-  disableAltpayment?: boolean
+  altpayment?: string | boolean
   contributionOffset?: number
   setNewTxs?: Function
   disableSound?: boolean
@@ -128,7 +128,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       apiBaseUrl = config.apiBaseUrl,
       successText,
       hoverText,
-      disableAltpayment,
+      altpayment,
       contributionOffset,
       altpaymentShift,
       setAltpaymentShift,
@@ -424,7 +424,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
           setAltpaymentShift={setAltpaymentShift}
           shiftCompleted={shiftCompleted}
           setShiftCompleted={setShiftCompleted}
-          disableAltpayment={disableAltpayment}
+          altpayment={altpayment}
           contributionOffset={contributionOffset}
           transactionText={transactionText}
           donationAddress={donationAddress}

--- a/react/lib/tests/util/altpayment.test.ts
+++ b/react/lib/tests/util/altpayment.test.ts
@@ -2,13 +2,17 @@ import { parseAltpayment } from '../../util/altpayment'
 
 describe('parseAltpayment', () => {
   const defaultConfig = { showAltpaymentLink: true, autoStart: false }
+  const disabledConfig = { showAltpaymentLink: false, autoStart: false }
 
-  it('returns default for undefined, null, empty, and false', () => {
+  it('returns default for undefined, null, and empty', () => {
     expect(parseAltpayment(undefined)).toEqual(defaultConfig)
     expect(parseAltpayment(null)).toEqual(defaultConfig)
     expect(parseAltpayment('')).toEqual(defaultConfig)
-    expect(parseAltpayment(false)).toEqual(defaultConfig)
-    expect(parseAltpayment('false')).toEqual(defaultConfig)
+  })
+
+  it('disables altpayment for false', () => {
+    expect(parseAltpayment(false)).toEqual(disabledConfig)
+    expect(parseAltpayment('false')).toEqual(disabledConfig)
   })
 
   it('returns default for true', () => {
@@ -17,10 +21,10 @@ describe('parseAltpayment', () => {
   })
 
   it('disables altpayment link for XEC and BCH', () => {
-    expect(parseAltpayment('XEC')).toEqual({ showAltpaymentLink: false, autoStart: false })
-    expect(parseAltpayment('xec')).toEqual({ showAltpaymentLink: false, autoStart: false })
-    expect(parseAltpayment('BCH')).toEqual({ showAltpaymentLink: false, autoStart: false })
-    expect(parseAltpayment('bch')).toEqual({ showAltpaymentLink: false, autoStart: false })
+    expect(parseAltpayment('XEC')).toEqual(disabledConfig)
+    expect(parseAltpayment('xec')).toEqual(disabledConfig)
+    expect(parseAltpayment('BCH')).toEqual(disabledConfig)
+    expect(parseAltpayment('bch')).toEqual(disabledConfig)
   })
 
   it('auto-starts with BTC preselected for BTC ticker', () => {

--- a/react/lib/tests/util/altpayment.test.ts
+++ b/react/lib/tests/util/altpayment.test.ts
@@ -39,5 +39,6 @@ describe('parseAltpayment', () => {
   it('returns default for unrecognized tickers', () => {
     expect(parseAltpayment('ETH')).toEqual(defaultConfig)
     expect(parseAltpayment('DOGE')).toEqual(defaultConfig)
+    expect(parseAltpayment('blahInvalidTicker')).toEqual(defaultConfig)
   })
 })

--- a/react/lib/tests/util/altpayment.test.ts
+++ b/react/lib/tests/util/altpayment.test.ts
@@ -1,0 +1,43 @@
+import { parseAltpayment } from '../../util/altpayment'
+
+describe('parseAltpayment', () => {
+  const defaultConfig = { showAltpaymentLink: true, autoStart: false }
+
+  it('returns default for undefined, null, empty, and false', () => {
+    expect(parseAltpayment(undefined)).toEqual(defaultConfig)
+    expect(parseAltpayment(null)).toEqual(defaultConfig)
+    expect(parseAltpayment('')).toEqual(defaultConfig)
+    expect(parseAltpayment(false)).toEqual(defaultConfig)
+    expect(parseAltpayment('false')).toEqual(defaultConfig)
+  })
+
+  it('returns default for true', () => {
+    expect(parseAltpayment(true)).toEqual(defaultConfig)
+    expect(parseAltpayment('true')).toEqual(defaultConfig)
+  })
+
+  it('disables altpayment link for XEC and BCH', () => {
+    expect(parseAltpayment('XEC')).toEqual({ showAltpaymentLink: false, autoStart: false })
+    expect(parseAltpayment('xec')).toEqual({ showAltpaymentLink: false, autoStart: false })
+    expect(parseAltpayment('BCH')).toEqual({ showAltpaymentLink: false, autoStart: false })
+    expect(parseAltpayment('bch')).toEqual({ showAltpaymentLink: false, autoStart: false })
+  })
+
+  it('auto-starts with BTC preselected for BTC ticker', () => {
+    expect(parseAltpayment('BTC')).toEqual({
+      showAltpaymentLink: false,
+      autoStart: true,
+      preselectedCoin: 'BTC',
+    })
+    expect(parseAltpayment('btc')).toEqual({
+      showAltpaymentLink: false,
+      autoStart: true,
+      preselectedCoin: 'BTC',
+    })
+  })
+
+  it('returns default for unrecognized tickers', () => {
+    expect(parseAltpayment('ETH')).toEqual(defaultConfig)
+    expect(parseAltpayment('DOGE')).toEqual(defaultConfig)
+  })
+})

--- a/react/lib/util/altpayment.ts
+++ b/react/lib/util/altpayment.ts
@@ -9,9 +9,18 @@ const DEFAULT_CONFIG: ParsedAltpayment = {
   autoStart: false,
 }
 
+const DISABLED_CONFIG: ParsedAltpayment = {
+  showAltpaymentLink: false,
+  autoStart: false,
+}
+
 export function parseAltpayment (value?: string | boolean | null): ParsedAltpayment {
-  if (value === undefined || value === null || value === '' || value === false || value === 'false') {
+  if (value === undefined || value === null || value === '') {
     return DEFAULT_CONFIG
+  }
+
+  if (value === false || value === 'false') {
+    return DISABLED_CONFIG
   }
 
   if (value === true || value === 'true') {
@@ -21,7 +30,7 @@ export function parseAltpayment (value?: string | boolean | null): ParsedAltpaym
   const ticker = String(value).toUpperCase()
 
   if (ticker === 'XEC' || ticker === 'BCH') {
-    return { showAltpaymentLink: false, autoStart: false }
+    return DISABLED_CONFIG
   }
 
   if (ticker === 'BTC') {

--- a/react/lib/util/altpayment.ts
+++ b/react/lib/util/altpayment.ts
@@ -1,0 +1,32 @@
+export type ParsedAltpayment = {
+  showAltpaymentLink: boolean
+  autoStart: boolean
+  preselectedCoin?: string
+}
+
+const DEFAULT_CONFIG: ParsedAltpayment = {
+  showAltpaymentLink: true,
+  autoStart: false,
+}
+
+export function parseAltpayment (value?: string | boolean | null): ParsedAltpayment {
+  if (value === undefined || value === null || value === '' || value === false || value === 'false') {
+    return DEFAULT_CONFIG
+  }
+
+  if (value === true || value === 'true') {
+    return DEFAULT_CONFIG
+  }
+
+  const ticker = String(value).toUpperCase()
+
+  if (ticker === 'XEC' || ticker === 'BCH') {
+    return { showAltpaymentLink: false, autoStart: false }
+  }
+
+  if (ticker === 'BTC') {
+    return { showAltpaymentLink: false, autoStart: true, preselectedCoin: 'BTC' }
+  }
+
+  return DEFAULT_CONFIG
+}

--- a/react/lib/util/index.ts
+++ b/react/lib/util/index.ts
@@ -13,4 +13,5 @@ export * from './number';
 export * from './currency';
 export * from './validate';
 export * from './autoClose';
+export * from './altpayment';
 


### PR DESCRIPTION
<!-- Non-technical -->
Description
---
Expanded the 'altpayments' config functionality (renaming it in the process and inverting the true/false behaviour)


Test plan
---
Test everything, but especially the "altpayment" (Sideshift) payment flow. Try setting `altpayments` to `true`, `false`, `xec`, `btc`, and `blahInvalidTicker` to make sure it behaves as you'd expect.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated “Advanced Usage” and parameter docs (including sidebars) across supported languages to use `altpayment` instead of `disable-altpayment`, with updated XEC/BCH/BTC examples.
* **New Features**
  * Updated the payment button demos and generator UI to configure `altpayment` via dropdown options.
  * Improved widget behavior to initialize and render the altpayment flow based on `altpayment` (including automatic BTC preselection).
* **Tests**
  * Added coverage for `altpayment` configuration parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->