### PR TITLE
fix: Removed unused style causing build error

### DIFF
--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -481,10 +481,6 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
     padding: '10px', borderRadius: '5px', color: 'red'
   })
 
-  const ShiftLabel = styled('span')({
-    fontSize: '14px', marginLeft: '5px', fontWeight: 600
-  })
-
   const ShiftStepLabel = styled('span', {
     shouldForwardProp: (prop) => prop !== 'active',
   })<{ active?: boolean }>(({ active }) => ({


### PR DESCRIPTION
Test plan
---
Try building `yarn build:dev` and make sure it works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated payment step labels with pill-shaped styling.
  * Improved visual distinction between active and inactive steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->